### PR TITLE
Fixing byid()

### DIFF
--- a/ehp.py
+++ b/ehp.py
@@ -259,7 +259,7 @@ class Root(list):
         None
         """
     
-        return self.take('id', id)
+        return self.take(('id', id))
 
     def take(self, *args):
         """


### PR DESCRIPTION
In function byid(), it's a tuple, not a string that is passed to take(). Otherwise, byid() will always return None.